### PR TITLE
Fix premature DB connection close in PHP scripts

### DIFF
--- a/sendungen.php
+++ b/sendungen.php
@@ -11,7 +11,7 @@
 //**************************
 
 
-include "strpl/includes/config.php";
+include "strpl/include/config.php";
 
 $conID = mysql_connect( $host, $user, $pass ) or die( "Die Datenbank konnte nicht erreicht werden!" );
 if ($conID)
@@ -54,6 +54,8 @@ $datum = date("d.m.Y",strtotime($start));
     	    		<td><? echo "$zeitvon"; ?></td> 
     				<td><? echo "$zeitbis"; ?></td> 
                     <?php echo "<td>" .$datensatz['details']. "</td>"; ?> 
-               </tr> <?php  mysql_close($conID); } ?>
-           </tbody> 
+                </tr>
+            <?php } ?>
+            </tbody>
 </table>
+<?php mysql_close($conID); ?>

--- a/strpl/output.php
+++ b/strpl/output.php
@@ -56,6 +56,8 @@ $datum = date("d.m.Y",strtotime($start));
           <?php // echo "<td>" .$datensatz['details']. "</td>"; ?> 
    
 
-                </tr> <?php  mysql_close($conID); } ?>
-</tbody> 
-</table>
+                 </tr>
+ <?php } ?>
+ </tbody>
+ </table>
+<?php mysql_close($conID); ?>


### PR DESCRIPTION
## Summary
- correct include path for config
- close MySQL connection outside of loops in `sendungen.php` and `strpl/output.php`

## Testing
- `php -l ../sendungen.php`
- `php -l output.php`


------
https://chatgpt.com/codex/tasks/task_e_688a87c681a8832a8adec908f9926b1e